### PR TITLE
fix incorrectly imported bottle websocket package with respect to Pyt…

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -13,7 +13,7 @@ from gevent.threading import Timer
 import gevent as gvt
 import json as jsn
 import bottle as btl
-import bottle.ext.websocket as wbs
+import bottle_websocket as wbs
 import re as rgx
 import os
 import eel.browsers as brw


### PR DESCRIPTION
…hon version 3.12

Python 3.12.1 seems to have a problem with importing bottle.ext.websocket. Replacing it with bottle_websocket fixes this.